### PR TITLE
Fix 1906 update token cname from iframe unsubscribe

### DIFF
--- a/CDNOptionsManager.php
+++ b/CDNOptionsManager.php
@@ -72,4 +72,13 @@ class CDNOptionsManager {
 		delete_transient( 'rocketcdn_status' );
 		rocket_clean_domain();
 	}
+
+	/**
+	 * Get current CDN cnames.
+	 *
+	 * @return array
+	 */
+	public function get_cdn_cnames() {
+		return $this->options->get( 'cdn_cnames', [] );
+	}
 }

--- a/Tests/Fixtures/DataManagerSubscriber/validateTokenCname.php
+++ b/Tests/Fixtures/DataManagerSubscriber/validateTokenCname.php
@@ -1,0 +1,115 @@
+<?php
+
+return [
+	'testShouldBailoutWhenBothValuesAreEmpty' => [
+			'config' => [
+				'cdn_url'   => '',
+				'cdn_token' => '',
+			],
+			'expected' => [
+				'empty' => true,
+				'data'  => [
+					'message' => 'cdn_values_empty',
+				],
+			],
+	],
+	'testShouldBailoutWhenCDNTokenIsEmpty' => [
+		'config' => [
+			'cdn_url'   => 'https://rocketcdn.me',
+			'cdn_token' => '',
+		],
+		'expected' => [
+			'empty' => true,
+			'data'  => [
+				'message' => 'cdn_values_empty',
+			],
+		],
+	],
+	'testShouldBailoutWhenCDNUrlIsEmpty' => [
+		'config' => [
+			'cdn_url'   => '',
+			'cdn_token' => 'TOKEN',
+		],
+		'expected' => [
+			'empty' => true,
+			'data'  => [
+				'message' => 'cdn_values_empty',
+			],
+		],
+	],
+	'testShouldFailAtValidatingCDNUrl' => [
+		'config' => [
+			'cdn_url'   => 'not_valid_cdn_url',
+			'cdn_token' => 'TOKEN',
+		],
+		'expected' => [
+			'empty'     => false,
+			'not_valid' => true,
+			'data'      => [
+				'message' => 'cdn_url_invalid_format',
+			],
+		],
+	],
+	'testShouldFailAtValidatingToken' => [
+		'config' => [
+			'cdn_url'   => 'https://rocketcdn.me',
+			'cdn_token' => 'not40charslong',
+		],
+		'expected' => [
+			'empty'     => false,
+			'not_valid' => true,
+			'data'      => [
+				'message' => 'invalid_token_length',
+			],
+		],
+	],
+	'testShouldDueToCurrentTokenSetAndCNameSet' => [
+		'config' => [
+			'cdn_url'       => 'https://rocketcdn.me',
+			'cdn_token'     => '9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b',
+			'current_token' => '9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b',
+			'current_cname' => 'https://rocketcdn.me',
+		],
+		'expected' => [
+			'empty'     => false,
+			'not_valid' => true,
+			'get_option' => true,
+			'data'      => [
+				'message' => 'token_already_set',
+			],
+		],
+	],
+	'testShouldDueToCurrentTokenSetAndCNameNotSet' => [
+		'config' => [
+			'cdn_url'       => 'https://rocketcdn.me',
+			'cdn_token'     => '9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b',
+			'current_token' => '9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b',
+			'current_cname' => '',
+		],
+		'expected' => [
+			'empty'      => false,
+			'not_valid'  => true,
+			'get_option' => true,
+			'data'       => [
+				'message' => 'token_already_set',
+			],
+		],
+	],
+	'testShouldUpdateTokenAndCname' => [
+		'config' => [
+			'cdn_url'       => 'https://rocketcdn.me',
+			'cdn_token'     => '9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b',
+			'current_token' => '',
+			'current_cname' => '',
+		],
+		'expected' => [
+			'empty'      => false,
+			'not_valid'  => false,
+			'success'    => true,
+			'get_option' => true,
+			'data'       => [
+				'message' => 'token_updated_successfully',
+			],
+		],
+	],
+];

--- a/Tests/Integration/DataManagerSubscriber/validateTokenCname.php
+++ b/Tests/Integration/DataManagerSubscriber/validateTokenCname.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace WP_Rocket\Tests\Integration\DataManagerSubscriber;
+
+/**
+ * @covers \WP_Rocket\Engine\CDN\RocketCDN\DataManagerSubscriber::validate_token_cname
+ *
+ * @group  AdminOnly
+ * @group  DataManagerSubscriber
+ */
+class Test_ValidateTokenCname extends AjaxTestCase {
+	protected static $ajax_action = 'rocketcdn_validate_token_cname';
+
+	public function testCallbackIsRegistered() {
+		$this->assertCallbackRegistered( 'wp_ajax_rocketcdn_validate_token_cname', 'validate_token_cname' );
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldSendExpectedResponse( $config, $expected ) {
+		$_POST['cdn_url']   = $config[ 'cdn_url' ];
+		$_POST['cdn_token'] = $config[ 'cdn_token' ];
+
+		if ( isset( $expected[ 'get_option' ] ) ) {
+			add_option( 'rocketcdn_user_token', $config['current_token'] );
+		}
+
+		$response = $this->callAjaxAction();
+
+		// Check the response.
+		$this->assertEquals( (object) $expected['data'], $response->data );
+
+		if ( isset( $expected[ 'success' ] ) ) {
+			$this->assertSame(
+				$config['cdn_token'],
+				get_option( 'rocketcdn_user_token' )
+			);
+		}
+	}
+}

--- a/Tests/Unit/CDNOptionsManager/getCdnCnames.php
+++ b/Tests/Unit/CDNOptionsManager/getCdnCnames.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\CDNOptionsManager;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WPMedia\PHPUnit\Unit\TestCase;
+use WP_Rocket\Engine\CDN\RocketCDN\CDNOptionsManager;
+use WP_Rocket\Admin\Options;
+use WP_Rocket\Admin\Options_Data;
+
+/**
+ * @covers \WP_Rocket\Engine\CDN\RocketCDN\CDNOptionsManager::get_cdn_cnames
+ *
+ * @group  CDNOptionsManager
+ */
+class Test_GetCdnCnames extends TestCase {
+	public function testShouldGetCdnCnames() {
+		$expected = [
+			'cdn_cnames' => [
+				'https://rocketcdn.me',
+			],
+		];
+
+		$options       = Mockery::mock( Options::class );
+		$options_array = Mockery::mock( Options_Data::class );
+
+		$options_array->shouldReceive( 'get' )
+				->once()
+				->with( 'cdn_cnames', [] )
+				->andReturn( $expected[ 'cdn_cnames' ] );
+
+		$cdn_cnames = ( new CDNOptionsManager(
+			$options,
+			$options_array
+		) )->get_cdn_cnames();
+
+		$this->assertEquals( $expected[ 'cdn_cnames' ], $cdn_cnames );
+	}
+}

--- a/Tests/Unit/DataManagerSubscriber/validateTokenCname.php
+++ b/Tests/Unit/DataManagerSubscriber/validateTokenCname.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace WP_Rocket\Tests\Unit\DataManagerSubscriber;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_Rocket\Tests\Unit\TestCase;
+use WP_Rocket\Engine\CDN\RocketCDN\APIClient;
+use WP_Rocket\Engine\CDN\RocketCDN\CDNOptionsManager;
+use WP_Rocket\Engine\CDN\RocketCDN\DataManagerSubscriber;
+
+/**
+ * @covers \WP_Rocket\Engine\CDN\RocketCDN\DataManagerSubscriber::validate_token_cname
+ *
+ * @group  DataManager
+ */
+class Test_ValidateTokenCname extends TestCase {
+	private $data_manager;
+	private $cdn_options_manager;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->cdn_options_manager = Mockery::mock( CDNOptionsManager::class );
+		$this->data_manager        = new DataManagerSubscriber(
+			Mockery::mock( APIClient::class ),
+			$this->cdn_options_manager
+		);
+
+		Functions\when( 'check_ajax_referer' )->justReturn( true );
+	}
+
+	public function testShouldSendErrorWhenNoPermissions() {
+		Functions\when( 'current_user_can' )->justReturn( false );
+		Functions\expect( 'wp_send_json_error' )->once()->with( [ 'message' => 'unauthorized_user' ] );
+
+		$this->data_manager->validate_token_cname();
+	}
+
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $config, $expected ) {
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$_POST['cdn_url']   = $config[ 'cdn_url' ];
+		$_POST['cdn_token'] = $config[ 'cdn_token' ];
+
+		if ( $expected[ 'empty' ] || $expected[ 'not_valid' ] ) {
+			Functions\expect( 'wp_send_json_error' )->once()->with( $expected[ 'data' ] );
+		}
+
+		Functions\when( 'sanitize_key' )->alias(
+			function ( $key ) {
+				$key = strtolower( $key );
+				return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+			}
+		);
+
+		Functions\when( 'wp_unslash' )->returnArg( );
+
+		if ( isset( $expected[ 'get_option' ] ) ) {
+			Functions\expect( 'get_option' )
+				->once()
+				->with( 'rocketcdn_user_token' )
+				->andReturn( $config[ 'current_token' ] );
+
+			$this->cdn_options_manager
+				->shouldReceive( 'get_cdn_cnames' )
+				->once()
+				->andReturn( $config[ 'current_cname' ] );
+		}
+
+		if ( isset( $expected[ 'success' ] ) ) {
+			Functions\expect( 'update_option' )
+				->once()
+				->with( 'rocketcdn_user_token', $config[ 'cdn_token' ] );
+
+			Functions\expect( 'esc_url_raw' )->once()->with( $config[ 'cdn_url' ] )->andReturnFirstArg();
+
+			$this->cdn_options_manager
+				->shouldReceive( 'enable' )
+				->once()
+				->with( $config[ 'cdn_url' ] );
+
+			Functions\expect( 'wp_send_json_success' )->once()->with( $expected[ 'data' ] );
+		}
+
+		$this->data_manager->validate_token_cname();
+	}
+}


### PR DESCRIPTION
Closes https://github.com/wp-media/wp-rocket.me/issues/1906

### Scope a solution ✅ 

**### 1. Modify rocketcdn.js and create a new function `validateTokenAndCNAME()`.**

In `window.onmessage` this function will be called. 

The function will receive 2 params `rocketcdn_validate_token` and `rocketcdn_validate_cname` and will make an AJAX call with the action `validate_rocketcdn_token_cname`.


**### 2.  \inc\Engine\CDN\RocketCDN\DataManagerSubscriber.php**

Create a new subscribed event: 'wp_ajax_validate_rocketcdn_token_cname'     => 'validate_token_cname',

In this function it will validate if the token and cname match.
In case the token and cname both are missing will update both values.
In case token is missing it will update token.
In case token is present will do nothing (ignoring what is in CNAME param).


### Estimate the effort ✅ 
Effort `[M]`